### PR TITLE
feat: surface job failure details

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -44,7 +44,8 @@ nersc-chat -A your_account -m meta-llama/Llama-3.1-8B-Instruct
 When the service is up, the CLI will output the service address and API key to
 stdout. If the deployment fails, backend logs and the job's Slurm state and exit
 code are shown to aid debugging. Optionally, you can use the `--json` flag to
-dump this information to a JSON file for easier programmatic access.
+dump this information to a JSON file for easier programmatic access. If startup
+often takes longer, adjust the waiting period with the `--timeout` option.
 
 ### CLI Options
 
@@ -59,6 +60,7 @@ dump this information to a JSON file for easier programmatic access.
 - `--constraint`, `-C` (default: `gpu`): Slurm node constraint
 - `--json`: Dump deployment info to a JSON file
 - `--log-level`, `-l` (default: `WARNING`): Logging verbosity level
+- `--timeout`, `-T` (default: `600`): Seconds to wait for job and service startup
 - `--help`: Show help message
 
 ## Python Library

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,10 +42,11 @@ nersc-chat -A your_account -m meta-llama/Llama-3.1-8B-Instruct
 ```
 
 When the service is up, the CLI will output the service address and API key to
-stdout. If the deployment fails, backend logs and the job's Slurm state and exit
-code are shown to aid debugging. Optionally, you can use the `--json` flag to
-dump this information to a JSON file for easier programmatic access. If startup
-often takes longer, adjust the waiting period with the `--timeout` option.
+stdout. If the deployment fails, any backend error output is surfaced immediately
+along with the job's Slurm state and exit code to aid debugging. Optionally, you
+can use the `--json` flag to dump this information to a JSON file for easier
+programmatic access. If startup often takes longer, adjust the waiting period
+with the `--timeout` option.
 
 ### CLI Options
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,7 +41,10 @@ export HF_HOME=$SCRATCH/huggingface
 nersc-chat -A your_account -m meta-llama/Llama-3.1-8B-Instruct
 ```
 
-When the service is up, the CLI will output the service address and API key to stdout. Optionally, you can use the `--json` flag to dump this information to a JSON file for easier programmatic access.
+When the service is up, the CLI will output the service address and API key to
+stdout. If the deployment fails, backend logs and the job's Slurm state and exit
+code are shown to aid debugging. Optionally, you can use the `--json` flag to
+dump this information to a JSON file for easier programmatic access.
 
 ### CLI Options
 
@@ -161,3 +164,5 @@ This script provides a basic framework for deploying vLLM across multiple nodes 
 - Verify Slurm queue and constraints match your allocation.
 - Check logs for errors; adjust `--log-level` for more verbosity.
 - Confirm network access for Gradio proxy URLs on JupyterHub.
+- On failure, the CLI now prints any backend error output and the job's final Slurm
+  state, exit code, and reason to help with debugging.

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,7 +43,7 @@ nersc-chat -A your_account -m meta-llama/Llama-3.1-8B-Instruct
 
 When the service is up, the CLI will output the service address and API key to
 stdout. If the deployment fails, any backend error output is surfaced immediately
-along with the job's Slurm state and exit code to aid debugging. Optionally, you
+along with the job's Slurm state, exit code, and reason to aid debugging. Optionally, you
 can use the `--json` flag to dump this information to a JSON file for easier
 programmatic access. If startup often takes longer, adjust the waiting period
 with the `--timeout` option.

--- a/src/nersc_chatbot_deploy/__init__.py
+++ b/src/nersc_chatbot_deploy/__init__.py
@@ -8,6 +8,7 @@ Gradio interfaces. It also configures the logging settings based on environment 
 Exports:
     - deploy_llm: Function to deploy large language models on Slurm clusters.
     - get_node_address: Function to retrieve the node address of a running Slurm job.
+    - get_job_failure_reason: Function to fetch a job's final state and exit code.
     - monitor_job_and_service: Function to monitor Slurm jobs and deployed services.
     - display_iframe: Utility to display an iframe for embedding Gradio UIs.
 """
@@ -15,12 +16,18 @@ Exports:
 import logging
 import os
 
-from .deploy import deploy_llm, get_node_address, monitor_job_and_service
+from .deploy import (
+    deploy_llm,
+    get_job_failure_reason,
+    get_node_address,
+    monitor_job_and_service,
+)
 from .gradio import display_iframe
 
 __all__ = [
     "monitor_job_and_service",
     "deploy_llm",
+    "get_job_failure_reason",
     "get_node_address",
     "display_iframe",
 ]

--- a/src/nersc_chatbot_deploy/cli.py
+++ b/src/nersc_chatbot_deploy/cli.py
@@ -114,8 +114,8 @@ def deploy(
     Raises:
         typer.Exit: Exits with code 1 if deployment fails or times out.
     """
-    # Set the logging level based on the provided log_level option
-    logger.setLevel(getattr(logging, log_level.value))
+    # Configure the root logger so settings propagate to all modules
+    logging.getLogger().setLevel(getattr(logging, log_level.value))
     logger.info(
         f"Starting deployment with model={model}, account={account}, num_gpus={num_gpus}, job_name={job_name or 'auto-generated'}"
     )

--- a/src/nersc_chatbot_deploy/cli.py
+++ b/src/nersc_chatbot_deploy/cli.py
@@ -15,7 +15,11 @@ from typing import Dict
 import typer
 from typing_extensions import Annotated
 
-from nersc_chatbot_deploy.deploy import deploy_llm, monitor_job_and_service
+from nersc_chatbot_deploy.deploy import (
+    deploy_llm,
+    get_job_failure_reason,
+    monitor_job_and_service,
+)
 from nersc_chatbot_deploy.util import (
     LogLevel,
     SupportedBackends,
@@ -150,6 +154,7 @@ def deploy(
         # Use monitor_job_and_service to wait for job and service readiness
         LLM_address = monitor_job_and_service(
             job_name=job_name,
+            process=process,
             api_url_template="http://{node_address}:8000/v1",
             endpoint="/models",
             api_key=llm_api_key,
@@ -162,7 +167,8 @@ def deploy(
 
         if LLM_address is None:
             logger.error("Failed to detect running job or service. Exiting.")
-            typer.echo("❌ Error: Deployment failed or timed out.")
+            reason = get_job_failure_reason(job_name)
+            typer.echo(f"❌ Error: Deployment failed or timed out. Job state: {reason}")
             if process:
                 process.terminate()
             raise typer.Exit(code=1)

--- a/src/nersc_chatbot_deploy/cli.py
+++ b/src/nersc_chatbot_deploy/cli.py
@@ -94,6 +94,14 @@ def deploy(
     log_level: Annotated[
         LogLevel, typer.Option("--log-level", "-l", help="Set the logging level.")
     ] = LogLevel.WARNING,
+    timeout: Annotated[
+        int,
+        typer.Option(
+            "--timeout",
+            "-T",
+            help="Seconds to wait for job and service startup before failing.",
+        ),
+    ] = 600,
 ) -> None:
     """
     Deploys the LLM using the specified backend with the provided parameters.
@@ -110,6 +118,7 @@ def deploy(
         constraint (str): Slurm constraint for node selection (default "gpu").
         dump_json (bool): Whether to dump deployment info to a JSON file.
         log_level (LogLevel): Logging verbosity level.
+        timeout (int): Seconds to wait for job and service startup before failing.
 
     Raises:
         typer.Exit: Exits with code 1 if deployment fails or times out.
@@ -159,8 +168,8 @@ def deploy(
             endpoint="/models",
             api_key=llm_api_key,
             expected_status=200,
-            job_timeout=600,  # optional: adjust timeouts as needed
-            service_timeout=600,
+            job_timeout=timeout,
+            service_timeout=timeout,
             job_interval=30,
             service_interval=30,
         )

--- a/src/nersc_chatbot_deploy/deploy.py
+++ b/src/nersc_chatbot_deploy/deploy.py
@@ -291,8 +291,31 @@ def check_service_status(
         return False
 
 
+def get_job_failure_reason(job_name: str) -> str:
+    """Return the final Slurm job state, exit code and reason."""
+
+    try:
+        sacct_cmd = f"sacct --name={shlex.quote(job_name)} -X --format=State,ExitCode,Reason --noheader"
+        output = subprocess.check_output(shlex.split(sacct_cmd), text=True).strip()
+        if not output:
+            return "unknown"
+        last_line = [line for line in output.splitlines() if line.strip()][-1]
+        parts = last_line.split()
+        state = parts[0] if len(parts) > 0 else "unknown"
+        exit_code = parts[1] if len(parts) > 1 else "?"
+        reason = " ".join(parts[2:]) if len(parts) > 2 else ""
+        return f"{state} (ExitCode: {exit_code}, Reason: {reason})"
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Failed to retrieve job failure reason: {e}")
+        return "unknown"
+    except Exception as e:
+        logger.error(f"Unexpected error retrieving job failure reason: {e}")
+        return "unknown"
+
+
 def monitor_job_and_service(
     job_name: str,
+    process: Optional[subprocess.Popen] = None,
     api_url_template: str = "http://{node_address}:8000/v1",
     endpoint: str = "/models",
     api_key: Optional[str] = None,
@@ -307,6 +330,7 @@ def monitor_job_and_service(
 
     Args:
         job_name (str): The name of the Slurm job.
+        process (Optional[subprocess.Popen]): Process object returned by :func:`deploy_llm`.
         api_url_template (str): The template for the API URL with a `{node_address}` placeholder.
             Defaults to "http://{node_address}:8000/v1".
         endpoint (str): The endpoint to check the status. Default is "/models".
@@ -328,6 +352,19 @@ def monitor_job_and_service(
 
     # Check if the Slurm job is running
     while time.time() - start_time < job_timeout:
+        if process and process.poll() is not None and process.returncode != 0:
+            stdout, stderr = process.communicate()
+            logger.error(
+                f"Process for job {job_name} failed early with code {process.returncode}."
+            )
+            if stdout:
+                logger.error(f"stdout: {stdout}")
+            if stderr:
+                logger.error(f"stderr: {stderr}")
+            reason = get_job_failure_reason(job_name)
+            logger.error(f"Job {job_name} state: {reason}")
+            return None
+
         node_address = get_node_address(job_name)
         if node_address:
             logger.info(f"Job {job_name} is running.")
@@ -339,6 +376,8 @@ def monitor_job_and_service(
         time.sleep(job_interval)
     else:
         logger.error("Job did not start within the timeout period.")
+        reason = get_job_failure_reason(job_name)
+        logger.error(f"Job {job_name} state: {reason}")
         return None
 
     # Construct the API URL using the node address
@@ -371,4 +410,6 @@ def monitor_job_and_service(
         time.sleep(service_interval)
     else:
         logger.error("Service did not start within the timeout period.")
+        reason = get_job_failure_reason(job_name)
+        logger.error(f"Job {job_name} state: {reason}")
         return None

--- a/src/nersc_chatbot_deploy/deploy.py
+++ b/src/nersc_chatbot_deploy/deploy.py
@@ -10,6 +10,7 @@ import json
 import logging
 import os
 import secrets
+import select
 import shlex
 import string
 import subprocess
@@ -291,6 +292,23 @@ def check_service_status(
         return False
 
 
+def get_job_state(job_name: str) -> Optional[str]:
+    """Return the latest Slurm job state if available."""
+
+    try:
+        sacct_cmd = f"sacct --name={shlex.quote(job_name)} -X --format=State --noheader"
+        output = subprocess.check_output(shlex.split(sacct_cmd), text=True).strip()
+        if not output:
+            return None
+        last_line = [line for line in output.splitlines() if line.strip()][-1]
+        return last_line.split()[0]
+    except subprocess.CalledProcessError:
+        return None
+    except Exception as e:
+        logger.error(f"Unexpected error retrieving job state: {e}")
+        return None
+
+
 def get_job_failure_reason(job_name: str) -> str:
     """Return the final Slurm job state, exit code and reason."""
 
@@ -349,9 +367,22 @@ def monitor_job_and_service(
         the job is running and the service is responsive or until timeouts occur.
     """
     start_time = time.time()
+    stderr_lines = []
 
     # Check if the Slurm job is running
     while time.time() - start_time < job_timeout:
+        if process and process.stderr:
+            try:
+                ready, _, _ = select.select([process.stderr], [], [], 0)
+                while ready:
+                    line = process.stderr.readline()
+                    if not line:
+                        break
+                    stderr_lines.append(line)
+                    ready, _, _ = select.select([process.stderr], [], [], 0)
+            except Exception as e:
+                logger.debug(f"stderr read error: {e}")
+
         if process and process.poll() is not None and process.returncode != 0:
             stdout, stderr = process.communicate()
             logger.error(
@@ -360,7 +391,9 @@ def monitor_job_and_service(
             if stdout:
                 logger.error(f"stdout: {stdout}")
             if stderr:
-                logger.error(f"stderr: {stderr}")
+                stderr_lines.append(stderr)
+            if stderr_lines:
+                logger.error("stderr: %s", "".join(stderr_lines).strip())
             reason = get_job_failure_reason(job_name)
             logger.error(f"Job {job_name} state: {reason}")
             return None
@@ -369,15 +402,28 @@ def monitor_job_and_service(
         if node_address:
             logger.info(f"Job {job_name} is running.")
             break
-        else:
-            logger.info(
-                f"Job {job_name} is not running yet. Checking again in {job_interval} seconds..."
-            )
+
+        state = get_job_state(job_name)
+        if state and state not in {"PENDING", "RUNNING"}:
+            logger.error(f"Job {job_name} finished early with state: {state}")
+            if stderr_lines:
+                logger.error("stderr: %s", "".join(stderr_lines).strip())
+            else:
+                logger.error("No stderr output captured from job.")
+            reason = get_job_failure_reason(job_name)
+            logger.error(f"Job {job_name} state: {reason}")
+            return None
+
+        logger.info(
+            f"Job {job_name} is not running yet. Checking again in {job_interval} seconds..."
+        )
         time.sleep(job_interval)
     else:
         logger.error("Job did not start within the timeout period.")
         reason = get_job_failure_reason(job_name)
         logger.error(f"Job {job_name} state: {reason}")
+        if stderr_lines:
+            logger.error("stderr: %s", "".join(stderr_lines).strip())
         return None
 
     # Construct the API URL using the node address


### PR DESCRIPTION
## Summary
- detect early backend failures by monitoring the deployment process and grabbing Slurm state/exit code via `sacct`
- bubble up failure reasons to the CLI for user-friendly error messages
- document that backend logs and Slurm job state are now shown when deployments fail

## Testing
- `pytest -q`
- `flake8`
- `black --check src/nersc_chatbot_deploy`
- `isort --check src/nersc_chatbot_deploy`
- `mypy src/nersc_chatbot_deploy` *(fails: python_version 3.8 not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68b49ac16aa08321a98decf7d1670511